### PR TITLE
Allow control of batchSize and other variables through pelias configuration

### DIFF
--- a/src/BatchManager.js
+++ b/src/BatchManager.js
@@ -18,8 +18,13 @@ function BatchManager( opts ){
   // manager variable options
   this._opts = opts || {};
   if( !this._opts.flooding ){ this._opts.flooding = {}; }
-  if( !this._opts.flooding.pause ){ this._opts.flooding.pause = 10; } //50
-  if( !this._opts.flooding.resume ){ this._opts.flooding.resume = 2; } //8
+  // This represents the maximum number of concurrent requests to allow out at once.
+  if( !this._opts.flooding.pause ){ this._opts.flooding.pause = this._opts.dbclient.maxActiveRequests || 10; } //50
+  // When to resume sending bulk requests to server (# of active requests)
+  if( !this._opts.flooding.resume ){ this._opts.flooding.resume = this._opts.dbclient.resumeRequestCount || 2; } //8
+
+  // Set this from configuration fallback if it exists.
+  if( !this._opts.batchSize && this._opts.dbclient.batchSize){  this._opts.batchSize = this._opts.dbclient.batchSize}
 
   // internal variables
   this._current = new Batch( this._opts );

--- a/src/configValidation.js
+++ b/src/configValidation.js
@@ -8,7 +8,10 @@ const elasticsearch = require('elasticsearch');
 // esclient: object, validation performed by elasticsearch module
 const schema = Joi.object().keys({
   dbclient: {
-    statFrequency: Joi.number().integer().min(0)
+    statFrequency: Joi.number().integer().min(0),
+    maxActiveRequests: Joi.number().integer().min(1),
+    resumeRequestCount: Joi.number().integer().min(0),
+    batchSize: Joi.number().integer().min(1)
   },
   esclient: Joi.object().keys({
     requestTimeout: Joi.number().integer().min(0)

--- a/src/sink.js
+++ b/src/sink.js
@@ -1,10 +1,14 @@
 
 var through = require('through2'),
-    BatchManager = require('./BatchManager');
+    BatchManager = require('./BatchManager'),
+    config = require('pelias-config').generate();
 
 function streamFactory( opts ){
   opts = opts || {};
   if( !opts.client ){ opts.client = require('./client')(); }
+
+  // Empty dbclient will use defaults defined in source files.
+  if( !opts.dbclient) { opts.dbclient = config.dbclient || {} }
 
   var manager = new BatchManager( opts );
 


### PR DESCRIPTION
This allows you to further control batchSize and request count through pelias config json without having to modify the underlying source. Direct source overrides will still take precedence if they are being passed in from the individual importers which I feel there is an possible discussion to have about which should have main precedence.